### PR TITLE
Fix parser memory leaks

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -31,7 +31,7 @@
 
 #define out_of_memory() do {                    \
 		fprintf(stderr, "Out of memory.\n");    \
-		exit(EXIT_FAILURE);                     \
+		exit(EXIT_FAILURE); /* WTF my library just called exit() */                    \
 	} while (0)
 
 /* Sadly, strdup is not portable. */

--- a/src/statement.c
+++ b/src/statement.c
@@ -2,12 +2,12 @@
 
 // Capitalize the macro string
 static void format_macro(char *macro) {
-  int idx;
-  int macro_len = strlen(macro);
-
-  for (idx = 0; idx < macro_len; idx++) {
-    macro[idx] = (idx == 0) ? toupper(macro[idx]) : tolower(macro[idx]);
-  }
+    char *ptr = macro;
+    if (*ptr != '\0') *ptr = toupper(*ptr);
+            
+    while (*(++ptr) != '\0') {
+        *ptr = tolower(*ptr);
+    }
 }
 
 // Add elements to a JSON array


### PR DESCRIPTION
Strings duplicated by the lexer weren't cleaned up after statement conversion to JSON.

Because the json library exits on malloc error, there's not a reason to change the signatures of the statement functions since JSON manipulation is the only place where dynamic memory is allocated and not free'd.

I think the linked list should get refactored to include a pointer to the tail of the list to make append() calls constant time since it's the most frequent thing done in this code. I'll make a separate PR for that later.