### PR TITLE
Allow NOT actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ ON
 You can link against `libcogito` after it has been installed by including `cogito.h` in your C program. This will give you a `buffer` struct:
 
 ```c
-typedef struct cg_buf {
+typedef struct {
   size_t length;
   size_t capacity;
   char *content;
@@ -86,8 +86,8 @@ typedef struct cg_buf {
 and two functions: `cg_to_json` and `cg_to_iam`. The call signature for these functions is:
 
 ```c
-int cg_to_json(cg_buf_t *buffer, char *input);
-int cg_to_iam(cg_buf_t *buffer, char *input);
+int cg_to_json(cg_buf_t *buffer, char *str);
+int cg_to_iam(cg_buf_t *buffer, char *str);
 ```
 
 where the return value will be a 0 in the case of success and an error code otherwise.

--- a/amazon/libcogito.spec
+++ b/amazon/libcogito.spec
@@ -1,5 +1,5 @@
 Name:     libcogito
-Version:  0.1.1
+Version:  0.2.0
 Release:  1
 Summary:  Define your AWS IAM policies using an easy-to-read format.
 License:  MIT
@@ -10,6 +10,9 @@ Source0:  %{name}-%{version}.tar.gz
 Define your AWS IAM policies using an easy-to-read format.
 
 %changelog
+* Fri Jun 02 2017 Localytics <oss@localytics.com> - 0.2.0-1
+- Allow "NotAction" and "NotResource" keys.
+
 * Mon May 15 2017 Localytics <oss@localytics.com> - 0.1.1-1
 - Fix issue when the "Action" or "Resource" keys are not provided.
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([cogito], [0.1.1], [oss@localytics.com])
+AC_INIT([cogito], [0.2.0], [oss@localytics.com])
 
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libcogito (0.2.0-1) unstable; urgency=low
+
+  * Allow "NotAction" and "NotResource" keys.
+
+ -- Localytics <oss@localytics.com>  Fri, 02 Jun 2017 00:22:47 +0000
+
 libcogito (0.1.1-1) unstable; urgency=low
 
   * Fix issue when the "Action" or "Resource" keys are not provided.

--- a/src/bin-cogito.h
+++ b/src/bin-cogito.h
@@ -7,14 +7,7 @@
 #include "src/statement.h"
 #include "src/parser.h"
 
-/**
- * Convert the given input string to JSON and copy it onto the given buffer.
- */
 int cg_to_json(cg_buf_t *buffer, char *input);
-
-/**
- * Convert the given input string to IAM and copy it onto the given buffer.
- */
 int cg_to_iam(cg_buf_t *buffer, char *input);
 
 #endif

--- a/src/bin-cogito.h
+++ b/src/bin-cogito.h
@@ -7,7 +7,14 @@
 #include "src/statement.h"
 #include "src/parser.h"
 
+/**
+ * Convert the given input string to JSON and copy it onto the given buffer.
+ */
 int cg_to_json(cg_buf_t *buffer, char *input);
+
+/**
+ * Convert the given input string to IAM and copy it onto the given buffer.
+ */
 int cg_to_iam(cg_buf_t *buffer, char *input);
 
 #endif

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -1,18 +1,34 @@
-#ifndef COGITO_BUF
-#define COGITO_BUF
+#ifndef COGITO_BUFFER
+#define COGITO_BUFFER
 
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
-typedef struct cg_buf {
+/**
+ * A struct representing an expandable string. Contains the current length of
+ * the string, the current capacity of the string, and a pointer to the string
+ * itself.
+ */
+typedef struct {
   size_t length;
   size_t capacity;
   char *content;
 } cg_buf_t;
 
+/**
+ * Initialize and return a new cg_buf_t struct.
+ */
 cg_buf_t* cg_buf_build(void);
+
+/**
+ * Copy a given string onto the given buffer, expanding if necessary.
+ */
 int cg_buf_append(cg_buf_t *buffer, const char *str);
+
+/**
+ * Free the allocated buffer and its associated string.
+ */
 void cg_buf_free(cg_buf_t *buffer);
 
 #endif

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -18,16 +18,21 @@ typedef struct {
 
 /**
  * Initialize and return a new cg_buf_t struct.
+ * @return A newly allocated and initialized buffer struct
  */
 cg_buf_t* cg_buf_build(void);
 
 /**
  * Copy a given string onto the given buffer, expanding if necessary.
+ * @param buffer The buffer on which to append
+ * @param str The string to append onto the buffer
+ * @return An integer describing success (0 for success, 1 for failure)
  */
 int cg_buf_append(cg_buf_t *buffer, const char *str);
 
 /**
  * Free the allocated buffer and its associated string.
+ * @param buffer The buffer to free
  */
 void cg_buf_free(cg_buf_t *buffer);
 

--- a/src/cogito.h
+++ b/src/cogito.h
@@ -6,7 +6,14 @@
 #include "cogito/statement.h"
 #include "cogito/parser.h"
 
+/**
+ * Convert the given input string to JSON and copy it onto the given buffer.
+ */
 int cg_to_json(cg_buf_t *buffer, char *input);
+
+/**
+ * Convert the given input string to IAM and copy it onto the given buffer.
+ */
 int cg_to_iam(cg_buf_t *buffer, char *input);
 
 #endif

--- a/src/cogito.h
+++ b/src/cogito.h
@@ -8,11 +8,17 @@
 
 /**
  * Convert the given input string to JSON and copy it onto the given buffer.
+ * @param buffer The buffer on which to copy the converted JSON
+ * @param input The input string in IAM format
+ * @return An integer describing success (0 for success, error code for failure)
  */
 int cg_to_json(cg_buf_t *buffer, char *input);
 
 /**
  * Convert the given input string to IAM and copy it onto the given buffer.
+ * @param buffer The buffer on which to copy the converted JSON
+ * @param input The input string in JSON format
+ * @return An integer describing success (0 for success, error code for failure)
  */
 int cg_to_iam(cg_buf_t *buffer, char *input);
 

--- a/src/cogito.l
+++ b/src/cogito.l
@@ -10,6 +10,7 @@ allow     (?i:allow)
 deny      (?i:deny)
 macro     {allow}|{deny}
 on        (?i:on)
+not       (?i:not)
 item      [A-Za-z0-9:/\*\.\-\$\{\}_]+
 
 %option noinput
@@ -21,6 +22,7 @@ item      [A-Za-z0-9:/\*\.\-\$\{\}_]+
 {white}       {}
 {macro}       { yylval.str = strdup(yytext); return MACRO; }
 {on}          { yylval.str = "ON"; return ON; }
+{not}         { yylval.str = "NOT"; return NOT; }
 {item}        { yylval.str = strdup(yytext); return ITEM; }
 
 ";" return END;

--- a/src/linked_list.c
+++ b/src/linked_list.c
@@ -38,17 +38,6 @@ void cg_ll_print(cg_node_t *node) {
   printf("\n");
 }
 
-// The number of nodes in the list
-int cg_ll_size(cg_node_t *head) {
-  int size = 0;
-  cg_node_t *ptr;
-
-  cg_ll_foreach(head, ptr) {
-    size += 1;
-  }
-  return size;
-}
-
 // The sum of the size of all of the values in the list
 size_t cg_ll_val_size_sum(cg_node_t *head) {
   size_t size = 0;

--- a/src/linked_list.c
+++ b/src/linked_list.c
@@ -1,14 +1,14 @@
 #include "linked_list.h"
 
-static cg_node_t* cg_ll_build_node(char *val) {
+static cg_node_t* cg_ll_build_node(char *value) {
   cg_node_t *node = (cg_node_t *) malloc(sizeof(cg_node_t));
-  node->val = val;
+  node->value = value;
   node->next = NULL;
   return node;
 }
 
-void cg_ll_append(cg_list_t *list, char *val) {
-  cg_node_t *tail = cg_ll_build_node(val);
+void cg_ll_append(cg_list_t *list, char *value) {
+  cg_node_t *tail = cg_ll_build_node(value);
   cg_node_t *ptr = list->head;
 
   while(ptr->next != NULL) {
@@ -17,27 +17,27 @@ void cg_ll_append(cg_list_t *list, char *val) {
   ptr->next = tail;
 }
 
-cg_list_t* cg_ll_update(cg_list_t *list, char *val) {
+cg_list_t* cg_ll_update(cg_list_t *list, char *value) {
   if (list == NULL) {
-    return cg_ll_build(val);
+    return cg_ll_build(value);
   }
-  cg_ll_append(list, val);
+  cg_ll_append(list, value);
   return list;
 }
 
-cg_list_t* cg_ll_build(char *val) {
+cg_list_t* cg_ll_build(char *value) {
   cg_list_t *list = (cg_list_t *) malloc(sizeof(cg_list_t));
   list->negated = 0;
-  list->head = cg_ll_build_node(val);
+  list->head = cg_ll_build_node(value);
   return list;
 }
 
-size_t cg_ll_val_size_sum(cg_list_t *list) {
+size_t cg_ll_value_size_sum(cg_list_t *list) {
   size_t size = 0;
   cg_node_t *ptr;
 
   cg_ll_foreach(list, ptr) {
-    size += strlen(ptr->val);
+    size += strlen(ptr->value);
   }
   return size;
 }

--- a/src/linked_list.c
+++ b/src/linked_list.c
@@ -1,9 +1,15 @@
 #include "linked_list.h"
 
-// Append a node to the end of the list
-void cg_ll_append(cg_node_t *head, char *val) {
-  cg_node_t *tail = cg_ll_build(val);
-  cg_node_t *ptr = head;
+static cg_node_t* cg_ll_build_node(char *val) {
+  cg_node_t *node = (cg_node_t *) malloc(sizeof(cg_node_t));
+  node->val = val;
+  node->next = NULL;
+  return node;
+}
+
+void cg_ll_append(cg_list_t *list, char *val) {
+  cg_node_t *tail = cg_ll_build_node(val);
+  cg_node_t *ptr = list->head;
 
   while(ptr->next != NULL) {
     ptr = ptr->next;
@@ -11,52 +17,40 @@ void cg_ll_append(cg_node_t *head, char *val) {
   ptr->next = tail;
 }
 
-// Build the first node or append a node to the list
-cg_node_t* cg_ll_update(cg_node_t *head, char *val) {
-  if (head == NULL) {
+cg_list_t* cg_ll_update(cg_list_t *list, char *val) {
+  if (list == NULL) {
     return cg_ll_build(val);
   }
-  cg_ll_append(head, val);
-  return head;
+  cg_ll_append(list, val);
+  return list;
 }
 
-// Build a list node
-cg_node_t* cg_ll_build(char *val) {
-  cg_node_t *node = (cg_node_t*) malloc(sizeof(cg_node_t));
-  node->val = val;
-  node->next = NULL;
-  return node;
+cg_list_t* cg_ll_build(char *val) {
+  cg_list_t *list = (cg_list_t *) malloc(sizeof(cg_list_t));
+  list->negated = 0;
+  list->head = cg_ll_build_node(val);
+  return list;
 }
 
-// Print out the list starting at the given node
-void cg_ll_print(cg_node_t *node) {
-  cg_node_t *ptr;
-
-  cg_ll_foreach(node, ptr) {
-    printf("[%s]\n", ptr->val);
-  }
-  printf("\n");
-}
-
-// The sum of the size of all of the values in the list
-size_t cg_ll_val_size_sum(cg_node_t *head) {
+size_t cg_ll_val_size_sum(cg_list_t *list) {
   size_t size = 0;
   cg_node_t *ptr;
 
-  cg_ll_foreach(head, ptr) {
+  cg_ll_foreach(list, ptr) {
     size += strlen(ptr->val);
   }
   return size;
 }
 
-// Free the memory for the entire list
-void cg_ll_free(cg_node_t *head) {
-  cg_node_t *previous = head;
-  cg_node_t *current = head;
+void cg_ll_free(cg_list_t *list) {
+  cg_node_t *previous = list->head;
+  cg_node_t *current = list->head;
 
   while(current != NULL) {
     previous = current;
     current = current->next;
     free(previous);
   }
+
+  free(list);
 }

--- a/src/linked_list.c
+++ b/src/linked_list.c
@@ -42,6 +42,10 @@ size_t cg_ll_val_size_sum(cg_list_t *list) {
   return size;
 }
 
+void cg_ll_negate(cg_list_t *list) {
+  list->negated = 1 - list->negated;
+}
+
 void cg_ll_free(cg_list_t *list) {
   cg_node_t *previous = list->head;
   cg_node_t *current = list->head;

--- a/src/linked_list.h
+++ b/src/linked_list.h
@@ -1,24 +1,58 @@
-#ifndef COGITO_LL
-#define COGITO_LL
+#ifndef COGITO_LINKED_LIST
+#define COGITO_LINKED_LIST
 
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+/**
+ * A struct representing a node in the list. Contains a pointer to a string
+ * representing the AWS identifier and a pointer to the next node.
+ */
 typedef struct cg_node {
   char *val;
   struct cg_node *next;
 } cg_node_t;
 
-#define cg_ll_foreach(head, ptr) \
-  for ((ptr) = head; (ptr) != NULL; (ptr) = (ptr)->next)
+/**
+ * A struct representing the list. Contains a pointer to the head node of the
+ * list and an integer flag representing whether or not this list is negated.
+ */
+typedef struct {
+  struct cg_node *head;
+  int negated;
+} cg_list_t;
 
-void cg_ll_append(cg_node_t *head, char *val);
-cg_node_t* cg_ll_update(cg_node_t *head, char *val);
-cg_node_t* cg_ll_build(char *val);
-void cg_ll_print(cg_node_t *node);
-size_t cg_ll_val_size_sum(cg_node_t *head);
-void cg_ll_free(cg_node_t *head);
+/**
+ * A macro for looping through the nodes in the list.
+ */
+#define cg_ll_foreach(list, ptr) \
+  for ((ptr) = list->head; (ptr) != NULL; (ptr) = (ptr)->next)
+
+/**
+ * Append a node to the end of the list.
+ */
+void cg_ll_append(cg_list_t *list, char *val);
+
+/**
+ * Build the first node or append a node to the list.
+ */
+cg_list_t* cg_ll_update(cg_list_t *list, char *val);
+
+/**
+ * Build the first list node and return the list.
+ */
+cg_list_t* cg_ll_build(char *val);
+
+/**
+ * The sum of the size of all of the values in the list.
+ */
+size_t cg_ll_val_size_sum(cg_list_t *list);
+
+/**
+ * Free the memory for the entire list.
+ */
+void cg_ll_free(cg_list_t *list);
 
 #endif

--- a/src/linked_list.h
+++ b/src/linked_list.h
@@ -32,31 +32,42 @@ typedef struct {
 
 /**
  * Append a node to the end of the list.
+ * @param list The list on which to append the new value
+ * @param value The new value that should be appended to the list
  */
 void cg_ll_append(cg_list_t *list, char *value);
 
 /**
  * Build the first node or append a node to the list.
+ * @param list The list that should be updated (or created if NULL)
+ * @param value The new value that should be appended to the list
+ * @return The newly created or updated list
  */
 cg_list_t* cg_ll_update(cg_list_t *list, char *value);
 
 /**
  * Build the first list node and return the list.
+ * @param value The value to be used to create the first node
+ * @return The newly created list
  */
 cg_list_t* cg_ll_build(char *value);
 
 /**
  * The sum of the size of all of the values in the list.
+ * @param list The list to with which to compute the sum
+ * @return The size_t representing the sum
  */
 size_t cg_ll_value_size_sum(cg_list_t *list);
 
 /**
  * Negate the given list.
+ * @param list The list on which to flip the negated flag
  */
 void cg_ll_negate(cg_list_t *list);
 
 /**
  * Free the memory for the entire list.
+ * @param list The list to free
  */
 void cg_ll_free(cg_list_t *list);
 

--- a/src/linked_list.h
+++ b/src/linked_list.h
@@ -18,7 +18,6 @@ void cg_ll_append(cg_node_t *head, char *val);
 cg_node_t* cg_ll_update(cg_node_t *head, char *val);
 cg_node_t* cg_ll_build(char *val);
 void cg_ll_print(cg_node_t *node);
-int cg_ll_size(cg_node_t *head);
 size_t cg_ll_val_size_sum(cg_node_t *head);
 void cg_ll_free(cg_node_t *head);
 

--- a/src/linked_list.h
+++ b/src/linked_list.h
@@ -11,7 +11,7 @@
  * representing the AWS identifier and a pointer to the next node.
  */
 typedef struct cg_node {
-  char *val;
+  char *value;
   struct cg_node *next;
 } cg_node_t;
 
@@ -33,22 +33,22 @@ typedef struct {
 /**
  * Append a node to the end of the list.
  */
-void cg_ll_append(cg_list_t *list, char *val);
+void cg_ll_append(cg_list_t *list, char *value);
 
 /**
  * Build the first node or append a node to the list.
  */
-cg_list_t* cg_ll_update(cg_list_t *list, char *val);
+cg_list_t* cg_ll_update(cg_list_t *list, char *value);
 
 /**
  * Build the first list node and return the list.
  */
-cg_list_t* cg_ll_build(char *val);
+cg_list_t* cg_ll_build(char *value);
 
 /**
  * The sum of the size of all of the values in the list.
  */
-size_t cg_ll_val_size_sum(cg_list_t *list);
+size_t cg_ll_value_size_sum(cg_list_t *list);
 
 /**
  * Negate the given list.

--- a/src/linked_list.h
+++ b/src/linked_list.h
@@ -51,6 +51,11 @@ cg_list_t* cg_ll_build(char *val);
 size_t cg_ll_val_size_sum(cg_list_t *list);
 
 /**
+ * Negate the given list.
+ */
+void cg_ll_negate(cg_list_t *list);
+
+/**
  * Free the memory for the entire list.
  */
 void cg_ll_free(cg_list_t *list);

--- a/src/parser.y
+++ b/src/parser.y
@@ -15,13 +15,13 @@ extern int yyparse();
 extern YY_BUFFER_STATE yy_scan_string(char *str);
 extern void yy_delete_buffer(YY_BUFFER_STATE buffer);
 
-static void cleanup_statement_allocs(statement_t *stmt);
+static void cleanup_statement_allocs(cg_statement_t *stmt);
 %}
 
 %union {
   char *str;
   cg_list_t *list;
-  statement_t *stmt;
+  cg_statement_t *stmt;
 }
 
 %parse-param { JsonNode *json_arr }
@@ -42,21 +42,21 @@ static void cleanup_statement_allocs(statement_t *stmt);
 } list
 %destructor { 
   cleanup_statement_allocs($$);
-  stmt_free($$); 
+  cg_stmt_free($$); 
 } statement
 
 %%
 input:
   /* empty */
   | input statement { 
-    json_append_element(json_arr, stmt_to_json($2)); 
+    json_append_element(json_arr, cg_stmt_to_json($2)); 
     cleanup_statement_allocs($2);
-    stmt_free($2);
+    cg_stmt_free($2);
 }
 ;
 
 statement:
-  MACRO list ON list END    { $$ = stmt_build($1, $2, $4); }
+  MACRO list ON list END    { $$ = cg_stmt_build($1, $2, $4); }
 ;
 
 list:
@@ -83,7 +83,7 @@ static void cleanup_json_arr(JsonNode *json_arr) {
   json_delete(json_arr);
 }
 
-static void cleanup_statement_allocs(statement_t *stmt) {
+static void cleanup_statement_allocs(cg_statement_t *stmt) {
   cg_node_t *ptr;
 
   cg_ll_foreach(stmt->actions, ptr) {

--- a/src/parser.y
+++ b/src/parser.y
@@ -20,7 +20,7 @@ static void cleanup_statement_allocs(statement_t *stmt);
 
 %union {
   char *str;
-  cg_node_t *node;
+  cg_list_t *list;
   statement_t *stmt;
 }
 
@@ -29,21 +29,20 @@ static void cleanup_statement_allocs(statement_t *stmt);
 %token COMMA END MACRO ON ITEM
 
 %type <str> COMMA END MACRO ON ITEM
-%type <node> list
+%type <list> list
 %type <stmt> statement
-
 
 %destructor { free($$); } MACRO ITEM
 %destructor { 
-    cg_node_t *ptr;
-    cg_ll_foreach($$, ptr) {
-        free(ptr->val);
-    }
-    cg_ll_free($$);
+  cg_node_t *ptr;
+  cg_ll_foreach($$, ptr) {
+    free(ptr->val);
+  }
+  cg_ll_free($$);
 } list
 %destructor { 
-    cleanup_statement_allocs($$);
-    stmt_free($$); 
+  cleanup_statement_allocs($$);
+  stmt_free($$); 
 } statement
 
 %%
@@ -81,11 +80,11 @@ static void cleanup_json_arr(JsonNode *json_arr) {
 
 static void cleanup_statement_allocs(statement_t *stmt) {
     cg_node_t *ptr;
-  
+
     cg_ll_foreach(stmt->actions, ptr) {
       free(ptr->val);
     }
-  
+
     cg_ll_foreach(stmt->resources, ptr) {
       free(ptr->val);
     }

--- a/src/parser.y
+++ b/src/parser.y
@@ -36,7 +36,7 @@ static void cleanup_statement_allocs(statement_t *stmt);
 %destructor { 
   cg_node_t *ptr;
   cg_ll_foreach($$, ptr) {
-    free(ptr->val);
+    free(ptr->value);
   }
   cg_ll_free($$);
 } list
@@ -84,15 +84,15 @@ static void cleanup_json_arr(JsonNode *json_arr) {
 }
 
 static void cleanup_statement_allocs(statement_t *stmt) {
-    cg_node_t *ptr;
+  cg_node_t *ptr;
 
-    cg_ll_foreach(stmt->actions, ptr) {
-      free(ptr->val);
-    }
+  cg_ll_foreach(stmt->actions, ptr) {
+    free(ptr->value);
+  }
 
-    cg_ll_foreach(stmt->resources, ptr) {
-      free(ptr->val);
-    }
+  cg_ll_foreach(stmt->resources, ptr) {
+    free(ptr->value);
+  }
 }
 
 int cg_to_json(cg_buf_t *buffer, char *input) {

--- a/src/parser.y
+++ b/src/parser.y
@@ -26,10 +26,10 @@ static void cleanup_statement_allocs(statement_t *stmt);
 
 %parse-param { JsonNode *json_arr }
 
-%token COMMA END MACRO ON ITEM
+%token COMMA END MACRO ON NOT ITEM
 
-%type <str> COMMA END MACRO ON ITEM
-%type <list> list
+%type <str> COMMA END MACRO ON NOT ITEM
+%type <list> list list_content
 %type <stmt> statement
 
 %destructor { free($$); } MACRO ITEM
@@ -60,8 +60,13 @@ statement:
 ;
 
 list:
+  list_content              { $$ = $1; }
+  | NOT list_content        { cg_ll_negate($2); $$ = $2; }
+;
+
+list_content:
   ITEM                      { $$ = cg_ll_build($1); }
-  | list COMMA ITEM         { cg_ll_append($1, $3); $$ = $1; }
+  | list_content COMMA ITEM { cg_ll_append($1, $3); $$ = $1; }
 ;
 %%
 

--- a/src/statement.c
+++ b/src/statement.c
@@ -16,7 +16,7 @@ static void format_macro(char *macro) {
 static void add_elements_to_array(cg_list_t *list, JsonNode *array) {
   cg_node_t *ptr = list->head;
   while (ptr != NULL) {
-    json_append_element(array, json_mkstring(ptr->val));
+    json_append_element(array, json_mkstring(ptr->value));
     ptr = ptr->next;
   }
 }
@@ -72,7 +72,7 @@ static void add_elements_to_iam(cg_buf_t *buffer, cg_list_t *elements) {
   cg_node_t *ptr = elements->head;
   while (ptr != NULL) {
     cg_buf_append(buffer, "  ");
-    cg_buf_append(buffer, ptr->val);
+    cg_buf_append(buffer, ptr->value);
 
     if (ptr->next != NULL) {
       cg_buf_append(buffer, ",\n");

--- a/src/statement.c
+++ b/src/statement.c
@@ -38,7 +38,6 @@ static void add_macro_to_iam(cg_buf_t *buffer, char *macro) {
   }
 
   cg_buf_append(buffer, macro);
-  cg_buf_append(buffer, "\n");
 }
 
 // Add a list of statement elements to the IAM string buffer
@@ -60,9 +59,11 @@ static char* stmt_to_iam(cg_statement_t *stmt) {
   cg_buf_t *buffer = cg_buf_build();
 
   add_macro_to_iam(buffer, stmt->macro);
+  cg_buf_append(buffer, stmt->actions->negated ? " NOT\n" : "\n");
   add_elements_to_iam(buffer, stmt->actions);
 
-  cg_buf_append(buffer, "\nON\n");
+  cg_buf_append(buffer, "\nON");
+  cg_buf_append(buffer, stmt->resources->negated ? " NOT\n" : "\n");
   add_elements_to_iam(buffer, stmt->resources);
   cg_buf_append(buffer, ";");
 

--- a/src/statement.h
+++ b/src/statement.h
@@ -9,14 +9,14 @@
 #include "json.h"
 #include "linked_list.h"
 
-typedef struct statement {
+typedef struct {
   char *macro;
-  cg_node_t *actions;
-  cg_node_t *resources;
+  cg_list_t *actions;
+  cg_list_t *resources;
 } statement_t;
 
 void stmt_free(statement_t *stmt);
-statement_t* stmt_build(char *macro, cg_node_t *actions, cg_node_t *resources);
+statement_t* stmt_build(char *macro, cg_list_t *actions, cg_list_t *resources);
 JsonNode* stmt_to_json(statement_t *stmt);
 int cg_append_json_policy(cg_buf_t *buffer, JsonNode *json);
 

--- a/src/statement.h
+++ b/src/statement.h
@@ -1,5 +1,5 @@
-#ifndef COGITO_STMT
-#define COGITO_STMT
+#ifndef COGITO_STATEMENT
+#define COGITO_STATEMENT
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -9,6 +9,11 @@
 #include "json.h"
 #include "linked_list.h"
 
+/**
+ * A struct representing a cogito statement. Contains a string which is either
+ * ALLOW or DENY. Also contains a pointer to both a list of actions and a list
+ * of resources.
+ */
 typedef struct {
   char *macro;
   cg_list_t *actions;

--- a/src/statement.h
+++ b/src/statement.h
@@ -18,11 +18,36 @@ typedef struct {
   char *macro;
   cg_list_t *actions;
   cg_list_t *resources;
-} statement_t;
+} cg_statement_t;
 
-void stmt_free(statement_t *stmt);
-statement_t* stmt_build(char *macro, cg_list_t *actions, cg_list_t *resources);
-JsonNode* stmt_to_json(statement_t *stmt);
+/**
+ * Build a statement object from the given macro, actions, and resources.
+ * @param macro The text saying whether this is an ALLOW or DENY command
+ * @param actions The list of actions from AWS
+ * @param resource The list of resources from AWS
+ * @return The newly allocated and initialized statement
+ */
+cg_statement_t* cg_stmt_build(char *macro, cg_list_t *actions, cg_list_t *resources);
+
+/**
+ * Free an allocated statement
+ * @param stmt The statement to free
+ */
+void cg_stmt_free(cg_statement_t *stmt);
+
+/**
+ * Converts a given statement object to a JsonNode object.
+ * @param stmt The statement struct to convert to JSON
+ * @return A JSON node representing the statement
+ */
+JsonNode* cg_stmt_to_json(cg_statement_t *stmt);
+
+/**
+ * Append a JSON policy to a buffer.
+ * @param buffer The buffer on which to append the converted IAM syntax
+ * @param json The JSON node that should be converted and added to the buffer
+ * @return An integer describing success (0 for success, error code for failure)
+ */
 int cg_append_json_policy(cg_buf_t *buffer, JsonNode *json);
 
 #endif

--- a/tests/check_linked_list.c
+++ b/tests/check_linked_list.c
@@ -6,43 +6,43 @@
 
 START_TEST(test_cg_ll_append)
 {
-  cg_node_t *head = cg_ll_build("head");
-  cg_ll_append(head, "tail");
+  cg_list_t *list = cg_ll_build("head");
+  cg_ll_append(list, "tail");
 
-  ck_assert_str_eq(head->next->val, "tail");
-  cg_ll_free(head);
+  ck_assert_str_eq(list->head->next->val, "tail");
+  cg_ll_free(list);
 }
 END_TEST
 
 START_TEST(test_cg_ll_update)
 {
-  cg_node_t *head = cg_ll_update(NULL, "head");
-  ck_assert_str_eq(head->val, "head");
-  cg_ll_update(head, "tail");
+  cg_list_t *list = cg_ll_update(NULL, "head");
+  ck_assert_str_eq(list->head->val, "head");
+  cg_ll_update(list, "tail");
 
-  ck_assert_str_eq(head->next->val, "tail");
-  cg_ll_free(head);
+  ck_assert_str_eq(list->head->next->val, "tail");
+  cg_ll_free(list);
 }
 END_TEST
 
 START_TEST(test_cg_ll_build)
 {
-  cg_node_t *head = cg_ll_build("head");
+  cg_list_t *list = cg_ll_build("head");
 
-  ck_assert_str_eq(head->val, "head");
-  cg_ll_free(head);
+  ck_assert_str_eq(list->head->val, "head");
+  cg_ll_free(list);
 }
 END_TEST
 
 START_TEST(test_cg_ll_val_size_sum)
 {
-  cg_node_t *head = cg_ll_build("head");
-  cg_ll_append(head, "this is the body");
-  cg_ll_append(head, "tail");
+  cg_list_t *list = cg_ll_build("head");
+  cg_ll_append(list, "this is the body");
+  cg_ll_append(list, "tail");
 
-  size_t sum = cg_ll_val_size_sum(head);
+  size_t sum = cg_ll_val_size_sum(list);
   ck_assert_int_eq(sum, 24);
-  cg_ll_free(head);
+  cg_ll_free(list);
 }
 END_TEST
 

--- a/tests/check_linked_list.c
+++ b/tests/check_linked_list.c
@@ -9,7 +9,7 @@ START_TEST(test_cg_ll_append)
   cg_list_t *list = cg_ll_build("head");
   cg_ll_append(list, "tail");
 
-  ck_assert_str_eq(list->head->next->val, "tail");
+  ck_assert_str_eq(list->head->next->value, "tail");
   cg_ll_free(list);
 }
 END_TEST
@@ -17,10 +17,10 @@ END_TEST
 START_TEST(test_cg_ll_update)
 {
   cg_list_t *list = cg_ll_update(NULL, "head");
-  ck_assert_str_eq(list->head->val, "head");
+  ck_assert_str_eq(list->head->value, "head");
   cg_ll_update(list, "tail");
 
-  ck_assert_str_eq(list->head->next->val, "tail");
+  ck_assert_str_eq(list->head->next->value, "tail");
   cg_ll_free(list);
 }
 END_TEST
@@ -29,18 +29,18 @@ START_TEST(test_cg_ll_build)
 {
   cg_list_t *list = cg_ll_build("head");
 
-  ck_assert_str_eq(list->head->val, "head");
+  ck_assert_str_eq(list->head->value, "head");
   cg_ll_free(list);
 }
 END_TEST
 
-START_TEST(test_cg_ll_val_size_sum)
+START_TEST(test_cg_ll_value_size_sum)
 {
   cg_list_t *list = cg_ll_build("head");
   cg_ll_append(list, "this is the body");
   cg_ll_append(list, "tail");
 
-  size_t sum = cg_ll_val_size_sum(list);
+  size_t sum = cg_ll_value_size_sum(list);
   ck_assert_int_eq(sum, 24);
   cg_ll_free(list);
 }
@@ -58,7 +58,7 @@ Suite* linked_list_suite(void)
   tcase_add_test(tc_core, test_cg_ll_append);
   tcase_add_test(tc_core, test_cg_ll_update);
   tcase_add_test(tc_core, test_cg_ll_build);
-  tcase_add_test(tc_core, test_cg_ll_val_size_sum);
+  tcase_add_test(tc_core, test_cg_ll_value_size_sum);
   suite_add_tcase(s, tc_core);
 
   return s;

--- a/tests/check_linked_list.c
+++ b/tests/check_linked_list.c
@@ -34,19 +34,6 @@ START_TEST(test_cg_ll_build)
 }
 END_TEST
 
-START_TEST(test_cg_ll_size)
-{
-  cg_node_t *head = cg_ll_build("head");
-  cg_ll_append(head, "body1");
-  cg_ll_append(head, "body2");
-  cg_ll_append(head, "body3");
-
-  int size = cg_ll_size(head);
-  ck_assert_int_eq(size, 4);
-  cg_ll_free(head);
-}
-END_TEST
-
 START_TEST(test_cg_ll_val_size_sum)
 {
   cg_node_t *head = cg_ll_build("head");
@@ -71,7 +58,6 @@ Suite* linked_list_suite(void)
   tcase_add_test(tc_core, test_cg_ll_append);
   tcase_add_test(tc_core, test_cg_ll_update);
   tcase_add_test(tc_core, test_cg_ll_build);
-  tcase_add_test(tc_core, test_cg_ll_size);
   tcase_add_test(tc_core, test_cg_ll_val_size_sum);
   suite_add_tcase(s, tc_core);
 

--- a/tests/check_statement.c
+++ b/tests/check_statement.c
@@ -4,17 +4,17 @@
 #include <check.h>
 #include "../src/statement.h"
 
-START_TEST(test_stmt_build)
+START_TEST(test_cg_stmt_build)
 {
   cg_list_t *actions = cg_ll_build("s3:PutObject");
   cg_list_t *resources = cg_ll_build("s3:::test-bucket*/*");
-  statement_t *statement = stmt_build("allow", actions, resources);
+  cg_statement_t *statement = cg_stmt_build("allow", actions, resources);
 
   ck_assert_str_eq(statement->macro, "allow");
   ck_assert_str_eq(statement->actions->head->value, "s3:PutObject");
   ck_assert_str_eq(statement->resources->head->value, "s3:::test-bucket*/*");
 
-  stmt_free(statement);
+  cg_stmt_free(statement);
 }
 END_TEST
 
@@ -27,7 +27,7 @@ Suite* statement_suite(void)
   s = suite_create("Statement");
   tc_core = tcase_create("Core");
 
-  tcase_add_test(tc_core, test_stmt_build);
+  tcase_add_test(tc_core, test_cg_stmt_build);
   suite_add_tcase(s, tc_core);
 
   return s;

--- a/tests/check_statement.c
+++ b/tests/check_statement.c
@@ -11,8 +11,8 @@ START_TEST(test_stmt_build)
   statement_t *statement = stmt_build("allow", actions, resources);
 
   ck_assert_str_eq(statement->macro, "allow");
-  ck_assert_str_eq(statement->actions->head->val, "s3:PutObject");
-  ck_assert_str_eq(statement->resources->head->val, "s3:::test-bucket*/*");
+  ck_assert_str_eq(statement->actions->head->value, "s3:PutObject");
+  ck_assert_str_eq(statement->resources->head->value, "s3:::test-bucket*/*");
 
   stmt_free(statement);
 }

--- a/tests/check_statement.c
+++ b/tests/check_statement.c
@@ -6,13 +6,13 @@
 
 START_TEST(test_stmt_build)
 {
-  cg_node_t *actions = cg_ll_build("s3:PutObject");
-  cg_node_t *resources = cg_ll_build("s3:::test-bucket*/*");
+  cg_list_t *actions = cg_ll_build("s3:PutObject");
+  cg_list_t *resources = cg_ll_build("s3:::test-bucket*/*");
   statement_t *statement = stmt_build("allow", actions, resources);
 
   ck_assert_str_eq(statement->macro, "allow");
-  ck_assert_str_eq(statement->actions->val, "s3:PutObject");
-  ck_assert_str_eq(statement->resources->val, "s3:::test-bucket*/*");
+  ck_assert_str_eq(statement->actions->head->val, "s3:PutObject");
+  ck_assert_str_eq(statement->resources->head->val, "s3:::test-bucket*/*");
 
   stmt_free(statement);
 }

--- a/tests/integration/input.iam
+++ b/tests/integration/input.iam
@@ -1,2 +1,4 @@
 allow alpha, beta, gamma on delta, epsilon;
 deny zeta, eta on theta, iota, lambda;
+allow not mu, nu on xi;
+deny omicron on not pi, rho;

--- a/tests/integration/input.json
+++ b/tests/integration/input.json
@@ -27,5 +27,10 @@
     "Effect": "Allow",
     "Action": "mu",
     "Resource": "nu"
+  },
+  {
+    "Effect": "Allow",
+    "NotAction": "xi",
+    "NotResource": "omicron"
   }
 ]

--- a/tests/integration/output.iam
+++ b/tests/integration/output.iam
@@ -18,3 +18,8 @@ ALLOW
   mu
 ON
   nu;
+
+ALLOW NOT
+  xi
+ON NOT
+  omicron;

--- a/tests/integration/output.json
+++ b/tests/integration/output.json
@@ -22,5 +22,25 @@
       "iota",
       "lambda"
     ]
+  },
+  {
+    "Effect": "Allow",
+    "NotAction": [
+      "mu",
+      "nu"
+    ],
+    "Resource": [
+      "xi"
+    ]
+  },
+  {
+    "Effect": "Deny",
+    "Action": [
+      "omicron"
+    ],
+    "NotResource": [
+      "pi",
+      "rho"
+    ]
   }
 ]


### PR DESCRIPTION
PR does a couple of things. It standardizes our struct names to consistently use `cg_` as a prefix and `_t` as a suffix. It also adds a fair amount of documentation to the header files. Additionally it allows NotAction clauses (http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#NotAction) and NotResource clauses (http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#NotResource) which I did not realize were things. The new IAM syntax allows queries like:

```
ALLOW ... ON NOT ...;
ALLOW NOT ... ON ...;
ALLOW NOT ... ON NOT ...;
```